### PR TITLE
update documentation of fld(x,y) in div.jl

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -80,6 +80,16 @@ See also: [`div`](@ref)
 julia> fld(7.3,5.5)
 1.0
 ```
+Because of floating-point rounding `fld(x,y)` can lead to an *alleged* violation of the fld(x,y) == x/y condition:
+```jldoctest
+julia> fld(6.0/0.1)
+59.0
+julia> 6.0/0.1
+60.0
+julia> 6.0/big(0.1)
+59.99999999999999666933092612453056361837965690217069245739573412231113406246995
+```
+
 """
 fld(a, b) = div(a, b, RoundDown)
 


### PR DESCRIPTION
Added an example with explanation why floating-point rounding can lead to an alleged violation of the fld(x,y)==x/y condition